### PR TITLE
dancer-oriented dance checkin and a few bugs fixed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,14 @@
 # TODO
 
+### Known bugs
+
+[ ] On dance checkin, at least one user seems to have a date field, which breaks the datepicker because it's stored as a string-- need to pull date info out of checkin state object so that it's not altered accidentally, and then add it when I send the checkin object to the API call
+
 ### Finishing the necessary features
 
 [ ] Way to show that a student has passed out of fundamentals - need to have a clear check box
 
-[ ] History of classes that the student has attended
+[x] History of classes that the student has attended -- class checkins list on student info
 
 
 ### UI flow
@@ -19,14 +23,16 @@
 
 [x] Admin confirms, hits submit, and then the class checkin is submitted— this should probably be one big full-screen modal
 
-[ ] Replicate class checkin flow with modal confirm for dance checkin
+[x] Replicate class checkin flow with modal confirm for dance checkin
 
-[ ] Home page should be directions for students and dancers-- new student, class checkin, dance checkin, all flows confirmed by admin at end
+[x] Home page should be directions for students and dancers-- new student, class checkin, dance checkin, all flows confirmed by admin at end
 
 
 #### Other
 
-[ ] Form validation, especially for new student form— everything should check for name and email, new student form should check for waiver
+[ ] Add success/failure to admin sign in
+
+[x] Form validation, especially for new student form— everything should check for name and email, new student form should check for waiver
 
 [ ] Code of conduct and waiver should be in app and need to be signed— need to be included in the app
 

--- a/src/components/DanceCheckinForm/form.js
+++ b/src/components/DanceCheckinForm/form.js
@@ -4,56 +4,80 @@ import React, { PureComponent } from "react";
 import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 import { DateTimePicker } from 'react-widgets';
 import { addNewDanceCheckin, getProfiles } from "../../lib/api.js";
+import McsAlert from "../Utilities/alert.js";
+import { AdminConfirmButtonModal } from "../Utilities/confirmCheckinModal.js";
+
 
 type State = {};
 
 type Props = {};
 
 class DanceCheckinForm extends PureComponent<Props, State> {
+  defaultCheckin = {
+    date: new Date(),
+    firstName: "",
+    lastName: "",
+    email: "",
+    info: "New Dancer",
+    student: false,
+    waiverAgree: false
+  }
+
   state: State = {
-    checkin: {
-      date: new Date(),
-      firstName: "",
-      lastName: "",
-      email: "",
-      info: ""
-    },
-    profileList: {}
+    checkin: {...this.defaultCheckin},
+    profileList: {},
+    success: "",
+    error: ""
   };
 
   componentDidMount() {
+    // Get list of profiles
     getProfiles.on("value", (snapshot) => {
       var snapshotVal = snapshot.val();
       var profiles = {};
-      Object.keys(snapshotVal).forEach(function(key) {
-        profiles[snapshotVal[key].email] = {
-          firstName: snapshotVal[key].firstName,
-          lastName: snapshotVal[key].lastName,
-          email: snapshotVal[key].email
-        }
+      var defaultCheckin = this.defaultCheckin;
+      Object.keys(snapshotVal).forEach(function(key1) {
+        var thisProfile = snapshotVal[key1];
+        profiles[thisProfile.email] = {...defaultCheckin};
+        Object.keys(defaultCheckin).forEach(function(key2){
+          profiles[thisProfile.email][key2] = thisProfile[key2] ? thisProfile[key2] : profiles[thisProfile.email][key2]
+        });
+        profiles[thisProfile.email].info = "";
       });
       this.setState({profileList: profiles});
     });
+    // Set function for additional actions on submit, like a redirect
+    if (this.props.addActionsOnSubmit) {
+      this.addActionsOnSubmit = this.props.addActionsOnSubmit
+    } else {
+      this.addActionsOnSubmit = () => {}
+    }
   };
 
   onCheckinChange = (event: any) => {
-    const { target: { name, value } } = event;
+    const name = event.target.name;
+    const value = event.target.type === "checkbox" ? event.target.checked : event.target.value;
     var newStateCheckin = {...this.state.checkin};
-    newStateCheckin[name] = value;
+    if (name === "email") {
+      // fixes an issue where updating the email wouldn't properly update other fields
+      if (this.state.profileList[value]) {
+        newStateCheckin = Object.assign(newStateCheckin, this.state.profileList[value]);
+      } else {
+        newStateCheckin = Object.assign({...this.defaultCheckin}, {email: value});
+      }
+    } else {
+      newStateCheckin[name] = value;
+    }
     this.setState({checkin: newStateCheckin});
   };
 
   onCheckinSelectChange = (event: any) => {
     var value = event.target.value;
-    var newStateCheckin = {...this.state.checkin};
+    var newStateCheckin = {...this.defaultCheckin};
     if (value) {
-      newStateCheckin.firstName = this.state.profileList[value].firstName;
-      newStateCheckin.lastName = this.state.profileList[value].lastName;
-      newStateCheckin.email = this.state.profileList[value].email;
+      newStateCheckin = Object.assign(newStateCheckin, this.state.profileList[value])
     } else {
-      newStateCheckin.firstName = "";
-      newStateCheckin.lastName = "";
-      newStateCheckin.email = "";
+      newStateCheckin = {...this.defaultCheckin}
     }
     this.setState({checkin: newStateCheckin});
   };
@@ -66,13 +90,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
 
   clearForm() {
     this.setState({
-      checkin: {
-        date: new Date(),
-        firstName: "",
-        lastName: "",
-        email: "",
-        info: ""
-      }
+      checkin: {...this.defaultCheckin}
     });
   };
 
@@ -80,17 +98,35 @@ class DanceCheckinForm extends PureComponent<Props, State> {
     this.clearForm();
   };
 
-  onSubmit = (event: any) => {
-    event.preventDefault();
-    // Validate form
-    addNewDanceCheckin(this.state.checkin);
-    // Clear the form
-    this.clearForm();
+  onSubmit = (options) => {
+    var onSuccess = () => {
+      var successText = "Added dance checkin for " + this.state.checkin.email
+      console.log("Success! " + successText);
+      this.setState({success: successText});
+      this.addActionsOnSubmit({success: successText});
+    }
+    var onError = (errorText) => {
+      console.log("Error! " + errorText);
+      this.setState({error: errorText});
+      window.scrollTo(0, 0);
+    }
+
+    try {
+      addNewDanceCheckin({...this.state.checkin}).then(function(){
+        onSuccess();
+      }).catch(function(error){
+        onError(error.toString());
+      });
+    } catch(error) {
+      onError(error.toString());
+    }
   };
 
   render() {
     return (
       <div>
+        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0}></McsAlert>
+        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0}></McsAlert>
         <Form onSubmit={this.onSubmit}>
           <FormGroup>
             <Label for="date">Dance Date</Label>
@@ -122,12 +158,27 @@ class DanceCheckinForm extends PureComponent<Props, State> {
             <Label for="email">Email</Label><Input placeholder="Email" value={this.state.checkin.email} onChange={this.onCheckinChange} name="email" />
           </FormGroup>
           <br></br>
-          <FormGroup>
-            <Label for="info">Other Info</Label><Input type="textarea" placeholder="Misc info, e.g., a note if this person is a guest" onChange={this.onCheckinChange} value={this.state.checkin.info} name="info" />
+          <FormGroup check>
+            <Label check>
+              <Input onChange={this.onCheckinChange} name="student" type="checkbox" checked={this.state.checkin.student} />
+              Full time student, must show valid student ID
+            </Label>
           </FormGroup>
           <br></br>
-          <Button outline color="success" type="submit" value="Submit">Submit</Button>
-          <Button outline value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
+          <FormGroup check>
+            <Label check>
+              <Input onChange={this.onCheckinChange} name="waiverAgree" type="checkbox" checked={this.state.checkin.waiverAgree} />
+              Waiver: I realize that partner dancing is a full-contact sport, and I promise not to sue Mission City Swing if I happen to get hurt. <a href="#">Read full text here (but not yet)</a>
+            </Label>
+          </FormGroup>
+          <br></br>
+          {this.state.checkin.email.length > 0 &&
+            <div>
+              <AdminConfirmButtonModal buttonOptions={{color: "primary"}} afterConfirm={this.onSubmit} modalHeader="Confirm" modalBody="Please hand the tablet to the desk attendant for confirmation and payment. Thank you!" modalData={this.state.checkin}>Submit</AdminConfirmButtonModal>
+              <span className="mr-1"></span>
+              <Button outline value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
+            </div>
+          }
         </Form>
       </div>
     );

--- a/src/components/DanceCheckinForm/index.js
+++ b/src/components/DanceCheckinForm/index.js
@@ -1,18 +1,36 @@
 // @flow
 // src/components/DanceCheckinForm/index.js
 import React, { PureComponent } from "react";
-import DanceCheckinForm from "./form.js"
+import DanceCheckinForm from "./form.js";
+import ErrorBoundary from "../Utilities/catch.js";
 
 type Props = {};
 
 class DanceCheckinPage extends PureComponent<Props, State> {
+
+  addActionsOnSubmit = (options = null) => {
+    var toUrl = "/";
+    if (options.success || options.error) {
+      toUrl = toUrl + "?"
+      if (options.success) {
+        toUrl = toUrl + "success=" + options.success
+      }
+      if (options.error) {
+        toUrl = toUrl + "error=" + options.error
+      }
+    }
+    this.props.history.push(toUrl);
+    window.scrollTo(0, 0);
+  }
 
   render() {
     return (
       <div className="App">
         <h1>Dance</h1>
         <p>Create a new dance checkin object!</p>
-        <DanceCheckinForm></DanceCheckinForm>
+        <ErrorBoundary>
+	        <DanceCheckinForm addActionsOnSubmit={this.addActionsOnSubmit}></DanceCheckinForm>
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -3,25 +3,46 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Container, Row, Col, Button, Card, CardTitle, CardText } from 'reactstrap';
+import queryString from 'query-string';
 import { getCurrentUser } from "../../lib/api.js";
+import McsAlert from "../Utilities/alert.js";
 
 
 class Home extends Component {
   state: State = {
-    currentUser: {}
+    currentUser: {},
+    success: "",
+    error: ""
   };
 
   componentDidMount() {
     this.setState({
       currentUser: getCurrentUser()
     });
+    this.getAlertFromQuery();
   }
+
+  getAlertFromQuery = () => {
+    if (this.props.location) {
+      if (this.props.location.search) {
+        var parsedSearch = queryString.parse(this.props.location.search);
+        if (parsedSearch["success"]) {
+          this.setState({success: parsedSearch["success"]})
+        }
+        if (parsedSearch["error"]) {
+          this.setState({error: parsedSearch["error"]})
+        }
+      }
+    }
+  };
 
   render() {
 
     return (
       <div className="App">
         <div>
+          <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0}></McsAlert>
+          <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0}></McsAlert>
           <Container>
             <Row>
               <Col>
@@ -33,9 +54,9 @@ class Home extends Component {
               </Col>
               <Col>
                 <Card className="card-body text-center">
-                  <CardTitle>Returning Student Checkin</CardTitle>
-                  <CardText>Check in  a returing student.</CardText>
-                  <Link to="/class-checkin"><Button size="lg">Returning Student</Button></Link>
+                  <CardTitle>Returning Student Class Checkin</CardTitle>
+                  <CardText>Returning students check in here.</CardText>
+                  <Link to="/class-checkin"><Button size="lg">Class Checkin</Button></Link>
                 </Card>
               </Col>
               <Col>

--- a/src/components/ReturningStudentForm/index.js
+++ b/src/components/ReturningStudentForm/index.js
@@ -9,7 +9,17 @@ type Props = {};
 class ReturningStudentPage extends PureComponent<Props, State> {
 
   addActionsOnSubmit = (options = null) => {
-    this.props.history.push('/');
+    var toUrl = "/";
+    if (options.success || options.error) {
+      toUrl = toUrl + "?"
+      if (options.success) {
+        toUrl = toUrl + "success=" + options.success
+      }
+      if (options.error) {
+        toUrl = toUrl + "error=" + options.error
+      }
+    }
+    this.props.history.push(toUrl);
     window.scrollTo(0, 0);
   }
 

--- a/src/components/Users/index.js
+++ b/src/components/Users/index.js
@@ -35,7 +35,7 @@ class SignInUserForm extends PureComponent<Props, State> {
       window.location.href = "/";
     });
     // Clear the form
-    this.clearForm();
+    // this.clearForm();
   };
 
   render() {

--- a/src/components/Utilities/confirmButton.js
+++ b/src/components/Utilities/confirmButton.js
@@ -1,7 +1,7 @@
 // @flow
 // src/components/Utilities/confirmButton.js
 import React from 'react';
-import { Button, ButtonGroup, Popover, PopoverHeader, PopoverBody, Modal, ModalHeader, ModalBody, ModalFooter, FormGroup, Label, Input } from 'reactstrap';
+import { Button, ButtonGroup, Popover, PopoverHeader, PopoverBody } from 'reactstrap';
 
 class ConfirmButtonPopover extends React.Component {
   constructor(props) {
@@ -56,66 +56,4 @@ class ConfirmButtonPopover extends React.Component {
   }
 }
 
-class AdminConfirmButtonModal extends React.Component {
-  constructor(props) {
-    super(props);
-    this.toggle = this.toggle.bind(this);
-    this.confirm = this.confirm.bind(this);
-    this.onInfoChange = this.onInfoChange.bind(this);
-    this.state = {
-      modalOpen: false,
-      modalData: this.props.modalData
-    };
-  }
-
-  toggle() {
-    this.setState({
-      modalOpen: !this.state.modalOpen
-    });
-  }
-
-  confirm() {
-    this.props.afterConfirm({info: this.state.modalData.info});
-    this.setState({
-      modalOpen: !this.state.modalOpen
-    });
-  }
-
-  onInfoChange(event: any) {
-    const { target: { name, value } } = event;
-    var newData = {...this.state.modalData}
-    newData.info = value;
-    this.setState({modalData: newData})
-  }
-
-  render() {
-    return (
-      <span>
-        <Button {...this.props.buttonOptions} onClick={this.toggle}>
-          {this.props.children}
-        </Button>
-        <Modal {...this.props.modalOptions} isOpen={this.state.modalOpen} toggle={this.toggle}>
-          <ModalHeader toggle={this.toggle}>{this.props.modalHeader}</ModalHeader>
-          <ModalBody>
-            <div>{this.props.modalBody}</div>
-            <br></br>
-            <div>
-              <pre>{JSON.stringify(this.props.modalData, null, '\t')}</pre>
-            </div>
-            <div>
-              <FormGroup>
-                <Label for="info">Additional Info</Label><Input type="textarea" placeholder="New dancer? Guest?" onChange={this.onInfoChange} value={this.state.modalData.info} name="info" />
-              </FormGroup>
-            </div>
-          </ModalBody>
-          <ModalFooter>
-            <span>Admin Only</span>
-            <Button color="danger" outline onClick={this.confirm}>Confirm?</Button>
-          </ModalFooter>
-        </Modal>
-      </span>
-    );
-  }
-}
-
-export { ConfirmButtonPopover, AdminConfirmButtonModal };
+export { ConfirmButtonPopover };

--- a/src/components/Utilities/confirmCheckinModal.js
+++ b/src/components/Utilities/confirmCheckinModal.js
@@ -1,0 +1,78 @@
+// @flow
+// src/components/Utilities/confirmCheckinModal.js
+import React from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, FormGroup, Label, Input } from 'reactstrap';
+
+
+class AdminConfirmButtonModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.toggle = this.toggle.bind(this);
+    this.confirm = this.confirm.bind(this);
+    this.onInfoChange = this.onInfoChange.bind(this);
+    this.state = {
+      modalOpen: false,
+      modalData: this.props.modalData
+    };
+    console.log('constructor', this.state);
+  }
+
+  toggle() {
+    this.setState({
+      modalOpen: !this.state.modalOpen
+    });
+  }
+
+  confirm() {
+    this.props.afterConfirm({info: this.state.modalData.info});
+    this.setState({
+      modalOpen: !this.state.modalOpen
+    });
+  }
+
+  onInfoChange(event: any) {
+    const { target: { name, value } } = event;
+    var newData = {...this.state.modalData}
+    newData.info = value;
+    this.setState({modalData: newData})
+  }
+
+  componentDidUpdate() {
+    // fixes an issue where the modal info text box wouldn't properly update
+    if (this.state.modalData.info !== this.props.modalData.info) {
+      this.setState({modalData: this.props.modalData});
+    }
+  }
+
+
+  render() {
+    return (
+      <span>
+        <Button {...this.props.buttonOptions} onClick={this.toggle}>
+          {this.props.children}
+        </Button>
+        <Modal {...this.props.modalOptions} isOpen={this.state.modalOpen} toggle={this.toggle}>
+          <ModalHeader toggle={this.toggle}>{this.props.modalHeader}</ModalHeader>
+          <ModalBody>
+            <div>{this.props.modalBody}</div>
+            <br></br>
+            <div>
+              <pre>{JSON.stringify(this.props.modalData, null, '\t')}</pre>
+            </div>
+            <div>
+              <FormGroup>
+                <Label for="info">Additional Info</Label><Input type="textarea" placeholder="New dancer? Guest?" onChange={this.onInfoChange} value={this.state.modalData.info} name="info" />
+              </FormGroup>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <span>Admin Only</span>
+            <Button color="danger" outline onClick={this.confirm}>Confirm?</Button>
+          </ModalFooter>
+        </Modal>
+      </span>
+    );
+  }
+}
+
+export { AdminConfirmButtonModal };

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -46,10 +46,11 @@ export default class MyNavbar extends Component {
                 </DropdownToggle>
                 <DropdownMenu right>
                   <DropdownItem>
-                    <NavLink href="/dance">Dance Form</NavLink>
-                  </DropdownItem>
-                  <DropdownItem>
                     <NavLink href="/dance-checkin">Dance Checkin</NavLink>
+                  </DropdownItem>
+                  <DropdownItem divider />
+                  <DropdownItem>
+                    <NavLink href="/dance">Create or Update a Dance</NavLink>
                   </DropdownItem>
                 </DropdownMenu>
               </UncontrolledDropdown>
@@ -64,6 +65,7 @@ export default class MyNavbar extends Component {
                   <DropdownItem>
                     <NavLink href="/class-checkin">Class Checkin</NavLink>
                   </DropdownItem>
+                  <DropdownItem divider />
                   <DropdownItem>
                     <NavLink href="/student">Update Student Info</NavLink>
                   </DropdownItem>
@@ -77,10 +79,10 @@ export default class MyNavbar extends Component {
                   <DropdownItem>
                     <NavLink href="/new-user">New Admin User</NavLink>
                   </DropdownItem>
+                  <DropdownItem divider />
                   <DropdownItem>
                     <NavLink href="/signin">Sign In</NavLink>
                   </DropdownItem>
-                  <DropdownItem divider />
                   <DropdownItem>
                     <NavLink href="/" onClick={logOutCurrentUser}>Sign Out</NavLink>
                   </DropdownItem>

--- a/src/types.js
+++ b/src/types.js
@@ -32,6 +32,7 @@ export type DanceCheckin = {
   email: string,
   student: boolean,
   info: string,
+  waiverAgree: boolean,
   author: string
 };
 
@@ -42,6 +43,7 @@ export type ClassCheckin = {
   email: string,
   student: boolean,
   info: string,
+  waiverAgree: boolean,
   author: string
 };
 


### PR DESCRIPTION
* Dancer-oriented dance checkin flow, like class checkin flow
* Redirect back to home page shows nice alert confirming the checkin event for both dance and class checkins
* New student, class checkin, and dance checkin forms all validate that first name, last name, email, and waiver have been filled out-- when a new student agrees to the waiver, that setting stays on their profile, so they've effectively pre-argeed to the waiver for all following events
* Updated wording on home page to be a little more clear (IMO)
* Updated wording on nav bar links to somewhat distinguish between admin and student/dancer links with divider bars-- anything below the divider bar is for admins only