### PR TITLE
fix misc bugs around dance and class checkin flow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,15 @@
 
 ### Known bugs
 
-[ ] On dance checkin, at least one user seems to have a date field, which breaks the datepicker because it's stored as a string-- need to pull date info out of checkin state object so that it's not altered accidentally, and then add it when I send the checkin object to the API call
+[x] On dance checkin, at least one user seems to have a date field, which breaks the datepicker because it's stored as a string-- need to pull date info out of checkin state object so that it's not altered accidentally, and then add it when I send the checkin object to the API call
+
+[x] When entering new data for new dancer, bug introduced when updating the email-- clears other fields
+
+[x] Editing additonal info on class and dance checkin is broken
+
+[ ] Clear warning "Links must not point to '#'. Use a more descriptive href or use a button instead"
+
+[x] Dance and class checkins not saving additional info
 
 ### Finishing the necessary features
 

--- a/src/components/DanceCheckinForm/form.js
+++ b/src/components/DanceCheckinForm/form.js
@@ -14,7 +14,6 @@ type Props = {};
 
 class DanceCheckinForm extends PureComponent<Props, State> {
   defaultCheckin = {
-    date: new Date(),
     firstName: "",
     lastName: "",
     email: "",
@@ -24,6 +23,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
   }
 
   state: State = {
+    date: new Date(),
     checkin: {...this.defaultCheckin},
     profileList: {},
     success: "",
@@ -63,7 +63,11 @@ class DanceCheckinForm extends PureComponent<Props, State> {
       if (this.state.profileList[value]) {
         newStateCheckin = Object.assign(newStateCheckin, this.state.profileList[value]);
       } else {
-        newStateCheckin = Object.assign({...this.defaultCheckin}, {email: value});
+        // if the email isn't recognized, update the hidden "info" field to be the default
+        newStateCheckin = Object.assign(newStateCheckin, {
+          email: value,
+          info: this.defaultCheckin.info
+        });
       }
     } else {
       newStateCheckin[name] = value;
@@ -83,9 +87,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
   };
 
   onCheckinDateChange = (value) => {
-    var newStateCheckin = {...this.state.checkin};
-    newStateCheckin.date = value;
-    this.setState({checkin: newStateCheckin});
+    this.setState({date: value});
   };
 
   clearForm() {
@@ -112,7 +114,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
     }
 
     try {
-      addNewDanceCheckin({...this.state.checkin}).then(function(){
+      addNewDanceCheckin(Object.assign({...this.state.checkin}, options)).then(function(){
         onSuccess();
       }).catch(function(error){
         onError(error.toString());
@@ -133,7 +135,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
             <DateTimePicker 
               time={false}
               format={'dddd, MMMM Do YYYY'}
-              value={this.state.checkin.date}
+              value={this.state.date}
               name="date"
               onChange={this.onCheckinDateChange}
             />
@@ -161,7 +163,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
           <FormGroup check>
             <Label check>
               <Input onChange={this.onCheckinChange} name="student" type="checkbox" checked={this.state.checkin.student} />
-              Full time student, must show valid student ID
+              <strong>Full time student, must show valid student ID</strong>
             </Label>
           </FormGroup>
           <br></br>
@@ -174,7 +176,7 @@ class DanceCheckinForm extends PureComponent<Props, State> {
           <br></br>
           {this.state.checkin.email.length > 0 &&
             <div>
-              <AdminConfirmButtonModal buttonOptions={{color: "primary"}} afterConfirm={this.onSubmit} modalHeader="Confirm" modalBody="Please hand the tablet to the desk attendant for confirmation and payment. Thank you!" modalData={this.state.checkin}>Submit</AdminConfirmButtonModal>
+              <AdminConfirmButtonModal buttonOptions={{color: "primary"}} afterConfirm={this.onSubmit} modalHeader="Confirm" modalBody="Please hand the tablet to the desk attendant for confirmation and payment. Thank you!" modalData={Object.assign({date: this.state.date}, this.state.checkin)}>Submit</AdminConfirmButtonModal>
               <span className="mr-1"></span>
               <Button outline value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
             </div>

--- a/src/components/NewStudentForm/form.js
+++ b/src/components/NewStudentForm/form.js
@@ -174,7 +174,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
           <FormGroup check>
             <Label check>
               <Input onChange={this.onChange} name="student" type="checkbox" checked={this.state.student} />
-              Full time student, must show valid student ID
+              <strong>Full time student, must show valid student ID</strong>
             </Label>
           </FormGroup>
           <br></br>
@@ -277,7 +277,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
           <FormGroup check>
             <Label check>
               <Input onChange={this.onChange} name="emailOptIn" type="checkbox" checked={this.state.emailOptIn} />
-              I would like to receive email from Mission City Swing
+              <strong>I would like to receive email from Mission City Swing</strong>
             </Label>
           </FormGroup>
           <br></br>
@@ -288,7 +288,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
           <FormGroup check>
             <Label check>
               <Input onChange={this.onChange} name="waiverAgree" type="checkbox" checked={this.state.waiverAgree} />
-              Waiver: I realize that partner dancing is a full-contact sport, and I promise not to sue Mission City Swing if I happen to get hurt. <a href="#">Read full text here (but not yet)</a>
+              <strong>Waiver: I realize that partner dancing is a full-contact sport, and I promise not to sue Mission City Swing if I happen to get hurt. <a href="#">Read full text here (but not yet)</a></strong>
             </Label>
           </FormGroup>
           <br></br>

--- a/src/components/ReturningStudentForm/form.js
+++ b/src/components/ReturningStudentForm/form.js
@@ -17,7 +17,6 @@ type Props = {};
 class ReturningStudentForm extends PureComponent<Props, State> {
 
   defaultCheckin = {
-    date: new Date(),
     firstName: "",
     lastName: "",
     email: "",
@@ -28,6 +27,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
   }
 
   state: State = {
+    date: new Date(),
     checkin: {...this.defaultCheckin},
     profileList: {},
     success: "",
@@ -93,7 +93,11 @@ class ReturningStudentForm extends PureComponent<Props, State> {
       if (this.state.profileList[value]) {
         newStateCheckin = Object.assign(newStateCheckin, this.state.profileList[value]);
       } else {
-        newStateCheckin = Object.assign({...this.defaultCheckin}, {email: value});
+        // if the email isn't recognized, update the hidden "info" field to be the default
+        newStateCheckin = Object.assign(newStateCheckin, {
+          email: value,
+          info: this.defaultCheckin.info
+        });
       }
     } else {
       newStateCheckin[name] = value;
@@ -113,9 +117,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
   };
 
   onCheckinDateChange = (value) => {
-    var newStateCheckin = {...this.state.checkin};
-    newStateCheckin.date = value;
-    this.setState({checkin: newStateCheckin});
+    this.setState({date: value});
   };
 
   onMultiTypeCheckinChange = (event: any) => {
@@ -156,14 +158,6 @@ class ReturningStudentForm extends PureComponent<Props, State> {
   };
 
   onSubmit = (options) => {
-    // If additional info added by admin
-    if (options.info) {
-      var newCheckin = {...this.state.checkin}
-      newCheckin.info = options.info
-      this.setState({
-        checkin: newCheckin
-      })
-    }
     // Error handling
     var onSuccess = () => {
       var successText = "Added class checkin for " + this.state.checkin.email
@@ -181,7 +175,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
     }
     // DB request
     try {
-      addNewClassCheckin({...this.state.checkin}).then(function(success) {
+      addNewClassCheckin(Object.assign({...this.state.checkin}, options)).then(function(success) {
         onSuccess();
       }).catch(function(error) {
         console.log(error);
@@ -205,7 +199,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
             <DateTimePicker 
               time={false}
               format={'dddd, MMMM Do YYYY'}
-              value={this.state.checkin.date}
+              value={this.state.date}
               name="date"
               onChange={this.onCheckinDateChange}
             />
@@ -269,9 +263,9 @@ class ReturningStudentForm extends PureComponent<Props, State> {
           <br></br>
           {this.state.checkin.email.length > 0 &&
             <div>
-            <AdminConfirmButtonModal buttonOptions={{color: "primary"}} afterConfirm={this.onSubmit} modalHeader="Confirm" modalBody="Please hand the tablet to the desk attendant for confirmation and payment. Thank you!" modalData={this.state.checkin}>Submit</AdminConfirmButtonModal>
-            <span className="mr-1"></span>
-            <Button outline value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
+              <AdminConfirmButtonModal buttonOptions={{color: "primary"}} afterConfirm={this.onSubmit} modalHeader="Confirm" modalBody="Please hand the tablet to the desk attendant for confirmation and payment. Thank you!" modalData={Object.assign({date: this.state.date}, this.state.checkin)}>Submit</AdminConfirmButtonModal>
+              <span className="mr-1"></span>
+              <Button outline value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
             </div>
           }
         </Form>

--- a/src/components/Students/checkins.js
+++ b/src/components/Students/checkins.js
@@ -3,6 +3,7 @@
 import React, { PureComponent } from "react";
 import queryString from 'query-string';
 import { getClassCheckinByEmail, getDanceCheckinByEmail } from "../../lib/api.js";
+import { sortByDate } from '../../lib/utils.js'
 
 type State = {};
 
@@ -10,8 +11,8 @@ type Props = {};
 
 class StudentCheckinList extends PureComponent<Props, State> {
   state: State = {
-    danceCheckinList: {},
-    classCheckinList: {}
+    danceCheckinList: [],
+    classCheckinList: []
   };
 
   getStudentFromQuery = () => {
@@ -27,16 +28,26 @@ class StudentCheckinList extends PureComponent<Props, State> {
 
   getCheckinsFromStudentEmail = (studentEmail) => {
     getClassCheckinByEmail(studentEmail).on("value", (snapshot) => {
-      console.log(snapshot.val())
-      this.setState({
-        classCheckinList: snapshot.val() || {}
-      });
+      var classCheckinList = [];
+      if (snapshot.val()) {
+        var checkinListObj = snapshot.val();
+        Object.keys(checkinListObj).map(function(uid) {
+          return classCheckinList.push(Object.assign({uid: uid}, checkinListObj[uid]))
+        })
+      }
+      classCheckinList.sort(sortByDate)
+      this.setState({classCheckinList: classCheckinList});
     });
     getDanceCheckinByEmail(studentEmail).on("value", (snapshot) => {
-      console.log(snapshot.val())
-      this.setState({
-        danceCheckinList: snapshot.val() || {}
-      });
+      var danceCheckinList = [];
+      if (snapshot.val()) {
+        var checkinListObj = snapshot.val();
+        Object.keys(checkinListObj).map(function(uid) {
+          return danceCheckinList.push(Object.assign({uid: uid}, checkinListObj[uid]))
+        })
+      }
+      danceCheckinList.sort(sortByDate)
+      this.setState({danceCheckinList: danceCheckinList});
     });
   };
 
@@ -49,16 +60,16 @@ class StudentCheckinList extends PureComponent<Props, State> {
     return (
       <div>
         <h5>Class Checkins</h5>
-        {Object.keys(this.state.classCheckinList).map((uid) => {
+        {this.state.classCheckinList.map(function(checkin) {
           return(
-            <div key={uid} value={uid}>Date: {this.state.classCheckinList[uid].date} | Classes: {this.state.classCheckinList[uid].classes.join(', ')}</div>
-          )
+            <div key={checkin.uid} value={checkin.uid}>Date: {checkin.date} | Classes: {checkin.classes.join(', ')} | Info: {checkin.info}</div>
+            )
         })}
         <br></br>
         <h5>Dance Checkins</h5>
         {Object.keys(this.state.danceCheckinList).map((uid) => {
           return(
-            <div key={uid} value={uid}>{this.state.danceCheckinList[uid].date}</div>
+            <div key={uid} value={uid}>Date: {this.state.danceCheckinList[uid].date} | Info: {this.state.danceCheckinList[uid].info}</div>
           )
         })}
       </div>

--- a/src/components/Utilities/confirmCheckinModal.js
+++ b/src/components/Utilities/confirmCheckinModal.js
@@ -14,36 +14,29 @@ class AdminConfirmButtonModal extends React.Component {
       modalOpen: false,
       modalData: this.props.modalData
     };
-    console.log('constructor', this.state);
   }
 
   toggle() {
+    if (this.state.modalOpen === false) {
+      this.setState({modalData: this.props.modalData})
+    }
     this.setState({
       modalOpen: !this.state.modalOpen
     });
   }
 
   confirm() {
-    this.props.afterConfirm({info: this.state.modalData.info});
+    this.props.afterConfirm(this.state.modalData);
     this.setState({
       modalOpen: !this.state.modalOpen
     });
   }
 
   onInfoChange(event: any) {
-    const { target: { name, value } } = event;
     var newData = {...this.state.modalData}
-    newData.info = value;
+    newData.info = event.target.value;
     this.setState({modalData: newData})
   }
-
-  componentDidUpdate() {
-    // fixes an issue where the modal info text box wouldn't properly update
-    if (this.state.modalData.info !== this.props.modalData.info) {
-      this.setState({modalData: this.props.modalData});
-    }
-  }
-
 
   render() {
     return (

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,13 +10,24 @@ function getSubstringIndex(list, subStr) {
   return(-1);
 };
 
-
 function MiscException(message, name = "MiscException") {
 	return {
     message: message,
     toString: function() { return name + ": " + message },
     name: name
 	}
-}
+};
 
-export { getSubstringIndex, MiscException }
+function sortByDate(a, b) {
+  // most recent checkins first
+  var [dateA, dateB] = [Date.parse(a.date), Date.parse(b.date)]
+  if (dateA > dateB) {
+    return -1
+  } else if (dateA < dateB) {
+    return 1
+  } else if (dateA === dateB) {
+    return 0
+  }
+};
+
+export { getSubstringIndex, MiscException, sortByDate }


### PR DESCRIPTION
* Fixed: On dance checkin, at least one user seems to have a date field, which breaks the datepicker because it's stored as a string-- need to pull date info out of checkin state object so that it's not altered accidentally, and then add it when I send the checkin object to the API call
* Fixed: When entering new data for new dancer, bug introduced when updating the email-- clears other fields
* Fixed: Editing additional info on class and dance checkin is broken
* Fixed: Dance and class checkins not saving additional info
* Fixed: Student checkins are listed by date