### PR TITLE
basic admin info for marking students as passed fundamentals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,39 +2,19 @@
 
 ### Known bugs
 
-[x] On dance checkin, at least one user seems to have a date field, which breaks the datepicker because it's stored as a string-- need to pull date info out of checkin state object so that it's not altered accidentally, and then add it when I send the checkin object to the API call
-
-[x] When entering new data for new dancer, bug introduced when updating the email-- clears other fields
-
-[x] Editing additonal info on class and dance checkin is broken
-
 [ ] Clear warning "Links must not point to '#'. Use a more descriptive href or use a button instead"
 
-[x] Dance and class checkins not saving additional info
+[x] After alert widget is closed, it doesn't reopen until the page is refreshed
+
 
 ### Finishing the necessary features
 
-[ ] Way to show that a student has passed out of fundamentals - need to have a clear check box
+[x] Way to show that a student has passed out of fundamentals - need to have a clear check box - TBH the way I did this isn't great, and I need to think more about how we will use this feature
 
 [x] History of classes that the student has attended -- class checkins list on student info
 
 
 ### UI flow
-
-#### Flow oriented towards the student signing themselves in, with the admin checking and receiving payment
-
-[x] New student form redirects to class checkin (returning student form)
-
-[x] Dance checkin, when redirected by new student form, should show student data
-
-[x] Dance checkin redirects to a page saying how much the student should pay and asking for confirmation from admin
-
-[x] Admin confirms, hits submit, and then the class checkin is submitted— this should probably be one big full-screen modal
-
-[x] Replicate class checkin flow with modal confirm for dance checkin
-
-[x] Home page should be directions for students and dancers-- new student, class checkin, dance checkin, all flows confirmed by admin at end
-
 
 #### Other
 
@@ -42,9 +22,9 @@
 
 [x] Form validation, especially for new student form— everything should check for name and email, new student form should check for waiver
 
-[ ] Code of conduct and waiver should be in app and need to be signed— need to be included in the app
+[ ] Code of conduct and waiver should be in app and need to be signed — need to be included in the app - blocked waiting for wavier and Code of Conduct text
 
-[ ] Remove "additional info" where possible, or maybe move it to the admin confirm page
+[x] Remove "additional info" where possible, or maybe move it to the admin confirm page
 
 
 ### Style

--- a/src/components/DanceCheckinForm/form.js
+++ b/src/components/DanceCheckinForm/form.js
@@ -100,6 +100,14 @@ class DanceCheckinForm extends PureComponent<Props, State> {
     this.clearForm();
   };
 
+  toggleAlerts(event: any) {
+    console.log(event)
+    this.setState({
+      success: "",
+      error: ""
+    });
+  };
+
   onSubmit = (options) => {
     var onSuccess = () => {
       var successText = "Added dance checkin for " + this.state.checkin.email
@@ -127,8 +135,8 @@ class DanceCheckinForm extends PureComponent<Props, State> {
   render() {
     return (
       <div>
-        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0}></McsAlert>
-        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0}></McsAlert>
+        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
+        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
         <Form onSubmit={this.onSubmit}>
           <FormGroup>
             <Label for="date">Dance Date</Label>

--- a/src/components/NewStudentForm/form.js
+++ b/src/components/NewStudentForm/form.js
@@ -15,7 +15,8 @@ type State = Profile;
 type Props = {};
 
 class StudentInfoForm extends PureComponent<Props, State> {
-  state: State = {
+
+  defaultFields = {
     firstName: "",
     lastName: "",
     email: "",
@@ -28,20 +29,22 @@ class StudentInfoForm extends PureComponent<Props, State> {
     student: false,
     emailOptIn: true,
     waiverAgree: false,
-    info: "",
-    success: "",
-    error: ""
   };
 
-  componentDidMount() {
-    this.getStudentFromQuery();
+  state: State = Object.assign({...this.defaultFields}, {
+    success: "",
+    error: ""
+  });
 
+  componentDidMount() {
+    // When updating student info, we use the same form
+    this.getStudentFromQuery();
+    // Set function for additional actions on submit, like a redirect
     if (this.props.addActionsOnSubmit) {
       this.addActionsOnSubmit = this.props.addActionsOnSubmit
     } else {
       this.addActionsOnSubmit = () => {}
     }
-
   };
 
 
@@ -91,20 +94,14 @@ class StudentInfoForm extends PureComponent<Props, State> {
   };
 
   clearForm() {
+    this.setState({...this.defaultFields});
+  };
+
+  toggleAlerts(event: any) {
+    console.log(event)
     this.setState({
-      firstName: "",
-      lastName: "",
-      email: "",
-      phoneNumber: "",
-      discoveryMethod: "",
-      discoveryMethodFriend: "",
-      discoveryMethodOther: "",
-      otherDances: [],
-      otherDancesOther: "",
-      student: false,
-      emailOptIn: true,
-      waiverAgree: false,
-      info: ""
+      success: "",
+      error: ""
     });
   };
 
@@ -122,24 +119,15 @@ class StudentInfoForm extends PureComponent<Props, State> {
     var onError = (errorText) => {
       console.log("Error! " + errorText);
       this.setState({error: errorText});
-      window.scrollTo(0, 0);
     }
+
     try {
-      createOrUpdateProfile({
-        firstName: this.state.firstName,
-        lastName: this.state.lastName,
-        email: this.state.email,
-        phoneNumber: this.state.phoneNumber,
-        discoveryMethod: this.state.discoveryMethod,
-        discoveryMethodFriend: this.state.discoveryMethodFriend,
-        discoveryMethodOther: this.state.discoveryMethodOther,
-        otherDances: this.state.otherDances,
-        otherDancesOther: this.state.otherDancesOther,
-        student: this.state.student,
-        info: this.state.info,
-        emailOptIn: this.state.emailOptIn,
-        waiverAgree: this.state.waiverAgree
-      }).then(function(success) {
+      var toSubmit = {};
+      var newState = {...this.state};
+      Object.keys(this.defaultFields).map(function(key) {
+        return toSubmit[key] = newState[key];
+      })
+      createOrUpdateProfile(toSubmit).then(function(success) {
         onSuccess();
       }).catch(function(error) {
         console.log(error)
@@ -155,8 +143,8 @@ class StudentInfoForm extends PureComponent<Props, State> {
 
     return (
       <div>
-        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0}></McsAlert>
-        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0}></McsAlert>
+        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
+        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
         <Form onSubmit={this.onSubmit}>
           <FormGroup>
             <Label for="firstName">First Name</Label><Input placeholder="First Name" value={this.state.firstName} onChange={this.onChange} name="firstName" />
@@ -179,7 +167,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
           </FormGroup>
           <br></br>
           <FormGroup tag="fieldset">
-            <legend>How did you hear about us?</legend>
+            <legend className="h5">How did you hear about us?</legend>
             <FormGroup check>
               <Label check>
                 <Input onChange={this.onChange} type="radio" name="discoveryMethod" checked={this.state.discoveryMethod === 'friend'} value="friend" /> Friend
@@ -230,7 +218,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
           </FormGroup>
           <br></br>
           <FormGroup tag="fieldset">
-            <legend>Do you already know any of these partner dances? (Select all that apply.)</legend>
+            <legend className="h5">Do you already know any of these partner dances? (Select all that apply.)</legend>
             <FormGroup check>
               <Label check>
                 <Input onChange={this.onMultiChange} type="checkbox" name="otherDances" checked={this.state.otherDances.indexOf('Lindy hop') !== -1} value="Lindy hop" /> {' '} Lindy hop
@@ -279,10 +267,6 @@ class StudentInfoForm extends PureComponent<Props, State> {
               <Input onChange={this.onChange} name="emailOptIn" type="checkbox" checked={this.state.emailOptIn} />
               <strong>I would like to receive email from Mission City Swing</strong>
             </Label>
-          </FormGroup>
-          <br></br>
-          <FormGroup>
-            <Label for="info">Other Info</Label><Input type="textarea" placeholder="Misc info" onChange={this.onChange} value={this.state.info} name="info" />
           </FormGroup>
           <br></br>
           <FormGroup check>

--- a/src/components/ReturningStudentForm/form.js
+++ b/src/components/ReturningStudentForm/form.js
@@ -23,6 +23,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
     info: "New Dancer",
     student: false,
     waiverAgree: false,
+    completedFundamentals: false,
     classes: []
   }
 
@@ -47,6 +48,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
         Object.keys(defaultCheckin).forEach(function(key2){
           profiles[thisProfile.email][key2] = thisProfile[key2] ? thisProfile[key2] : profiles[thisProfile.email][key2]
         });
+        profiles[thisProfile.email].completedFundamentals = (thisProfile.adminInfo ? thisProfile.adminInfo : {}).completedFundamentals ? true : false
         profiles[thisProfile.email].info = "";
       });
       this.setState({profileList: profiles});
@@ -74,6 +76,7 @@ class ReturningStudentForm extends PureComponent<Props, State> {
               Object.keys(newStateCheckin).forEach(function(key){
                 newStateCheckin[key] = student[key] ? student[key] : newStateCheckin[key]
               });
+              newStateCheckin.completedFundamentals = (student.adminInfo ? student.adminInfo : {}).completedFundamentals ? true : false
               // Make sure to note if they're a new dancer
               newStateCheckin.info = parsedSearch["new-dancer"] ? "New Dancer" : "";
               this.setState({checkin: newStateCheckin});
@@ -93,9 +96,10 @@ class ReturningStudentForm extends PureComponent<Props, State> {
       if (this.state.profileList[value]) {
         newStateCheckin = Object.assign(newStateCheckin, this.state.profileList[value]);
       } else {
-        // if the email isn't recognized, update the hidden "info" field to be the default
+        // if the email isn't recognized, update the hidden fields to be the default
         newStateCheckin = Object.assign(newStateCheckin, {
           email: value,
+          completedFundamentals: this.defaultCheckin.completedFundamentals,
           info: this.defaultCheckin.info
         });
       }
@@ -157,6 +161,14 @@ class ReturningStudentForm extends PureComponent<Props, State> {
     this.clearForm();
   };
 
+  toggleAlerts(event: any) {
+    console.log(event)
+    this.setState({
+      success: "",
+      error: ""
+    });
+  };
+
   onSubmit = (options) => {
     // Error handling
     var onSuccess = () => {
@@ -191,8 +203,8 @@ class ReturningStudentForm extends PureComponent<Props, State> {
 
     return (
       <div>
-        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0}></McsAlert>
-        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0}></McsAlert>
+        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
+        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
         <Form onSubmit={this.onSubmit}>
           <FormGroup>
             <Label for="date">Dance Date</Label>
@@ -214,6 +226,9 @@ class ReturningStudentForm extends PureComponent<Props, State> {
               })}
             </select>
           </FormGroup>
+          {this.state.checkin.completedFundamentals && 
+            <p><strong>{this.state.checkin.firstName} {this.state.checkin.lastName} has completed the MCS fundamentals course.</strong></p>
+          }
           <FormGroup>
             <Label for="firstName">First Name</Label><Input placeholder="First Name" value={this.state.checkin.firstName} onChange={this.onCheckinChange} name="firstName" />
           </FormGroup>

--- a/src/components/Students/index.js
+++ b/src/components/Students/index.js
@@ -4,8 +4,9 @@
 import React, { PureComponent } from "react";
 import { Form, FormGroup, } from 'reactstrap';
 import queryString from 'query-string';
-import StudentInfoForm from "../NewStudentForm/form.js"
-import StudentCheckinList from "./checkins.js"
+import StudentInfoForm from "../NewStudentForm/form.js";
+import StudentCheckinList from "./checkins.js";
+import ProfileAdminInfoForm from "./infoForm.js";
 import { getProfiles } from "../../lib/api.js";
 
 type State = {};
@@ -73,6 +74,10 @@ class StudentPage extends PureComponent<Props, State> {
               </select>
             </FormGroup>
           </Form>
+        </div>
+        <br></br>
+        <div>
+          <ProfileAdminInfoForm {...this.props} ></ProfileAdminInfoForm>
         </div>
         <br></br>
         <hr/>

--- a/src/components/Students/infoForm.js
+++ b/src/components/Students/infoForm.js
@@ -1,0 +1,134 @@
+// @flow
+// src/components/Students/infoForm.js
+import React, { PureComponent } from "react";
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
+import queryString from 'query-string';
+import type { ProfileAdminInfo } from "../../types.js";
+import { createOrUpdateProfileAdminInfo, getProfileByEmail } from "../../lib/api.js";
+import McsAlert from "../Utilities/alert.js"
+
+
+type State = ProfileAdminInfo;
+
+type Props = {};
+
+class ProfileAdminInfoForm extends PureComponent<Props, State> {
+
+  defaultFields = {
+    completedFundamentals: false,
+    info: ""
+  }
+
+  state: State = {
+    email: "",
+    adminInfo: {...this.defaultFields},
+    success: "",
+    error: ""
+  }
+
+  componentDidMount() {
+    this.getStudentFromQuery();
+  };
+
+  getStudentFromQuery = () => {
+    if (this.props.location) {
+      var parsedSearch = queryString.parse(this.props.location.search);
+      if (this.props.location.search) {
+        var studentEmail = parsedSearch["email"];
+        this.getStudentFromEmail(studentEmail);
+      }
+    }
+  };
+
+  getStudentFromEmail = (studentEmail) => {
+    getProfileByEmail(studentEmail).on("value", (snapshot) => {
+      if (snapshot.val()) {
+        var adminInfo = snapshot.val()["adminInfo"] ? snapshot.val()["adminInfo"] : {};
+        var newAdminInfo = Object.assign({...this.state.adminInfo}, adminInfo)
+        this.setState({email: studentEmail, adminInfo: newAdminInfo});
+      }
+    });
+  }
+
+  onAdminInfoChange = (event: any) => {
+    const name = event.target.name;
+    const value = event.target.type === "checkbox" ? event.target.checked : event.target.value;
+    var newAdminInfo = {...this.state.adminInfo}
+    newAdminInfo[name] = value;
+    this.setState({adminInfo: newAdminInfo});
+  };
+
+  clearFormEvent = (event: any) => {
+    this.clearForm();
+  };
+
+  clearForm() {
+    this.setState({adminInfo: {...this.defaultFields}});
+  };
+
+  toggleAlerts(event: any) {
+    console.log(event)
+    this.setState({
+      success: "",
+      error: ""
+    });
+  };
+
+  onSubmit = (event: any) => {
+    if (event) {
+      event.preventDefault();
+    }
+    // Validate form
+    var onSuccess = () => {
+      var successText = "Updated admin info for " + this.state.email
+      console.log("Success! " + successText);
+      this.setState({success: successText});
+      // this.addActionsOnSubmit({email: this.state.email});
+    }
+    var onError = (errorText) => {
+      console.log("Error! " + errorText);
+      this.setState({error: errorText});
+      window.scrollTo(0, 0);
+    }
+    try {
+      var fullInfo = Object.assign({...this.state.adminInfo}, {email: this.state.email});
+      createOrUpdateProfileAdminInfo(fullInfo).then(function(success) {
+        onSuccess();
+      }).catch(function(error) {
+        console.log(error)
+        onError(error.toString());
+      })
+    } catch(error) {
+      console.log(error)
+      onError(error.toString());
+    }
+  };
+
+  render() {
+
+    return (
+      <div>
+        <McsAlert color="success" text={this.state.success} visible={this.state.success.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
+        <McsAlert color="danger" text={this.state.error} visible={this.state.error.length > 0} onToggle={this.toggleAlerts.bind(this)}></McsAlert>
+        <Form onSubmit={this.onSubmit}>
+          <FormGroup check>
+            <Label check>
+              <Input onChange={this.onAdminInfoChange} name="completedFundamentals" type="checkbox" checked={this.state.adminInfo.completedFundamentals} />
+              <strong>Student has completed the fundamentals program</strong>
+            </Label>
+          </FormGroup>
+          <br></br>
+          <FormGroup>
+            <Label for="info">Other Info</Label><Input type="textarea" placeholder="Misc info" onChange={this.onAdminInfoChange} value={this.state.adminInfo.info} name="info" />
+          </FormGroup>
+          <br></br>
+          <Button color="primary" value="submit" name="submit" onClick={this.onSubmit}>Update</Button>
+          <span className="mr-1"></span>
+          <Button value="clear" onClick={this.clearFormEvent}>Clear Form</Button>
+        </Form>
+      </div>
+    );
+  }
+}
+
+export default ProfileAdminInfoForm;

--- a/src/components/Utilities/alert.js
+++ b/src/components/Utilities/alert.js
@@ -8,20 +8,25 @@ class McsAlert extends React.Component {
     super(props);
 
     this.state = {
-      text: "",
-      visible: true
+      visible: true, 
+      elementId: "alert-" + this.props.color + "-" + this.props.text.length,
+      onToggle: this.props.onToggle ? this.props.onToggle : () => { this.setState({visible: !this.state.visible}) }
     };
-
-    this.onDismiss = this.onDismiss.bind(this);
   }
 
-  onDismiss() {
-    this.setState({ visible: false });
+  componentDidUpdate() {
+    if (this.state.visible && this.props.text.length > 0) {
+      var alertRect = document.getElementById(this.state.elementId).getBoundingClientRect()
+      window.scrollTo({
+        top: Math.abs(alertRect.top),
+        behavior: "smooth"
+      });
+    }
   }
 
   render() {
     return (
-      <Alert color={this.props.color} isOpen={this.state.visible && this.props.text.length > 0} toggle={this.onDismiss}>
+      <Alert id={this.state.elementId} color={this.props.color} isOpen={this.state.visible && this.props.text.length > 0} toggle={this.state.onToggle}>
         {this.props.text}
       </Alert>
     );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Profile, Dance, User } from "../types.js";
+import type { Profile, Dance, User, ClassCheckin, DanceCheckin, ProfileAdminInfo } from "../types.js";
 import uuidv3 from "uuid/v3";
 import Cookies from 'universal-cookie';
 // I don't know if I need this
@@ -46,6 +46,22 @@ export const createOrUpdateProfile = (options: Profile) => {
 };
 
 export const getProfiles = fireDB.database().ref("profiles/").orderByChild('lastName');
+
+// Admin Info API
+export const createOrUpdateProfileAdminInfo = (options: ProfileAdminInfo) => {
+  var currentUser = getCurrentUser();
+  if (currentUser.uuid == null) {
+    throw MiscException("Admin must log in to authorize this event", "AuthException")
+  }
+  options.author = currentUser.uuid;
+  if (!options.email) {
+    throw MiscException("Must include profile email", "FormException")
+  }
+  const profileId = uuidv3(options.email, MCS_APP);
+  // Don't want to add email to profile twice
+  delete options.email;
+  return fireDB.database().ref("profiles/" + profileId + "/adminInfo").set(options);
+};
 
 // Dance API
 export const getDances = fireDB.database().ref("dances/").orderByChild('date');

--- a/src/types.js
+++ b/src/types.js
@@ -17,6 +17,13 @@ export type Profile = {
   author: string
 };
 
+export type ProfileAdminInfo = {
+  email: string,
+  info: string,
+  completedFundamentals: boolean,
+  author: string
+};
+
 export type Dance = {
   date: string,
   title: string,


### PR DESCRIPTION
* Fixed: After alert widget is closed, it doesn't reopen until the page is refreshed
* Super basic way to show that a student has passed out of fundamentals, I really need to take a second pass at this
* Fixed: No more "additional info" fields anywhere that a dancer/student would be looking, but I think this option is important for admins to have to make notes about events or students
* Light refactoring (decluttering) in new student form logic