### PR TITLE
sort list of students/patrons by name

### DIFF
--- a/src/components/DanceForm/form.js
+++ b/src/components/DanceForm/form.js
@@ -34,12 +34,14 @@ class DanceForm extends PureComponent<Props, State> {
 
   getDanceFromUid = (danceId) => {
     getDance(danceId).on("value", (snapshot) => {
-      this.setState({
-        date: new Date(snapshot.val().date),
-        title: snapshot.val().title,
-        fbLink: snapshot.val().fbLink,
-        info: snapshot.val().info
-      });
+      if (snapshot.val()) {
+        this.setState({
+          date: new Date(snapshot.val().date),
+          title: snapshot.val().title,
+          fbLink: snapshot.val().fbLink,
+          info: snapshot.val().info
+        });
+      }
     });
   }
 

--- a/src/components/DanceForm/index.js
+++ b/src/components/DanceForm/index.js
@@ -28,12 +28,14 @@ class DancePage extends PureComponent<Props, State> {
     }
 
     getDances.on("value", (snapshot) => {
-      var dancesSnap = snapshot.val();
       var danceList = [];
-      Object.keys(dancesSnap).forEach((uid => {
-        danceList.push(Object.assign({uid: uid}, dancesSnap[uid]))
-      }))
-      danceList.sort(sortByDate)
+      var dancesSnap = snapshot.val();
+      if (dancesSnap) {
+        Object.keys(dancesSnap).forEach((uid => {
+          danceList.push(Object.assign({uid: uid}, dancesSnap[uid]))
+        }))
+        danceList.sort(sortByDate)
+      }
       this.setState({danceList: danceList});
     });
   };

--- a/src/components/NewStudentForm/index.js
+++ b/src/components/NewStudentForm/index.js
@@ -12,8 +12,8 @@ type Props = {};
 class NewStudentPage extends PureComponent<Props, State> {
 
   addActionsOnSubmit = (options = null) => {
-    var newDancer = options.newDancer ? "&new-dancer=true" : ""
-    var toUrl = '/class-checkin?email=' + encodeURIComponent(options.email) + newDancer
+    var newDancer = options.newDancer ? "&new-dancer=true" : "";
+    var toUrl = "/class-checkin?email=" + encodeURIComponent(options.email) + newDancer;
     this.props.history.push(toUrl);
     window.scrollTo(0, 0);
   }

--- a/src/components/Students/index.js
+++ b/src/components/Students/index.js
@@ -8,6 +8,7 @@ import StudentInfoForm from "../NewStudentForm/form.js";
 import StudentCheckinList from "./checkins.js";
 import ProfileAdminInfoForm from "./infoForm.js";
 import { getProfiles } from "../../lib/api.js";
+import { sortByNameAndEmail } from "../../lib/utils.js";
 
 type State = {};
 
@@ -17,7 +18,7 @@ class StudentPage extends PureComponent<Props, State> {
 
   state: State = {
   	selected: "",
-    profileList: {}
+    profileList: []
   };
 
   componentDidMount() {
@@ -31,15 +32,19 @@ class StudentPage extends PureComponent<Props, State> {
     }
 
     getProfiles.on("value", (snapshot) => {
+      var profiles = [];
       var snapshotVal = snapshot.val();
-      var profiles = {};
-      Object.keys(snapshotVal).forEach(function(key) {
-        profiles[snapshotVal[key].email] = {
-          firstName: snapshotVal[key].firstName,
-          lastName: snapshotVal[key].lastName,
-          email: snapshotVal[key].email
-        }
-      });
+      if (snapshotVal) {
+        Object.keys(snapshotVal).forEach(function(key) {
+          profiles.push({
+            firstName: snapshotVal[key].firstName,
+            lastName: snapshotVal[key].lastName,
+            email: snapshotVal[key].email,
+            uid: key
+          });
+        });
+      }
+      profiles.sort(sortByNameAndEmail)
       this.setState({profileList: profiles});
     });
   };
@@ -63,9 +68,9 @@ class StudentPage extends PureComponent<Props, State> {
             <FormGroup>
               <select onChange={this.onCheckinSelectChange} value={this.state.selected}>
                 <option value="">Please Select a Student</option>
-                {Object.keys(this.state.profileList).map((uid) => {
+                {this.state.profileList.map((profile) => {
                   return(
-                    <option key={uid} value={uid}>{this.state.profileList[uid].firstName} {this.state.profileList[uid].lastName}, {this.state.profileList[uid].email}</option>
+                    <option key={profile.uid} value={profile.uid}>{profile.firstName} {profile.lastName}, {profile.email}</option>
                   )
                 })}
               </select>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,25 +39,38 @@ function sortDateStrings(a, b) {
   } else if (aDate === bDate) {
     return 0
   }
-}
+};
+
+
+function sortByNameAndEmail(profileA, profileB) {
+  var nameA = (profileA.firstName + profileA.lastName + profileA.email).toLowerCase();
+  var nameB = (profileB.firstName + profileB.lastName + profileB.email).toLowerCase();
+  if (nameA > nameB) {
+    return 1
+  } else if (nameA < nameB) {
+    return -1
+  } else if (nameA === nameB) {
+    return 0
+  }
+};
 
 function currentYear() {
   var today = new Date();
   return today.getFullYear()
-}
+};
 
 function currentMonthIndex() {
   var today = new Date();
   return today.getMonth()
-}
+};
 
 function currentMonthString() {
   var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
   return months[currentMonthIndex()]
-}
+};
 
 function reactTableFuzzyMatchFilter(filter, row) {
   return String(row[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
-}
+};
 
-export { getSubstringIndex, MiscException, sortByDate, sortDateStrings, currentMonthIndex, currentMonthString, reactTableFuzzyMatchFilter, currentYear }
+export { getSubstringIndex, MiscException, sortByDate, sortDateStrings, sortByNameAndEmail, currentMonthIndex, currentMonthString, reactTableFuzzyMatchFilter, currentYear }


### PR DESCRIPTION
* Patrons/student drop-down selector for class and dance checkins just displays their first and last names, sorted by first name + last name + email

* Fixed a bug where some of the pages wouldn't load if there were no objects retrieved for that object type (dances, for example)