### PR TITLE
fix name sort to include spaces

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -43,8 +43,8 @@ function sortDateStrings(a, b) {
 
 
 function sortByNameAndEmail(profileA, profileB) {
-  var nameA = (profileA.firstName + profileA.lastName + profileA.email).toLowerCase();
-  var nameB = (profileB.firstName + profileB.lastName + profileB.email).toLowerCase();
+  var nameA = (profileA.firstName + " " + profileA.lastName + " " + profileA.email).toLowerCase();
+  var nameB = (profileB.firstName + " " + profileB.lastName + " " + profileB.email).toLowerCase();
   if (nameA > nameB) {
     return 1
   } else if (nameA < nameB) {


### PR DESCRIPTION
I thought that maybe sorting without adding the spaces might be more intuitive. That wasn't the case.